### PR TITLE
Bug Fix - Ionic Build  Failure

### DIFF
--- a/IonicMobileApp/src/pages/report-new/report-new.ts
+++ b/IonicMobileApp/src/pages/report-new/report-new.ts
@@ -136,7 +136,7 @@ export class ReportNewPage {
   autoFillAddress() {
     let lat = this.location.lat;
     let lng = this.location.lng;
-    this.nativeGeocoder.reverseGeocode(lat , lng).then((result: NativeGeocoderReverseResult) => {
+    this.nativeGeocoder.reverseGeocode(lat , lng).then((result: NativeGeocoderReverseResult[]) => {
       console.log('--> ReportNewPage: Result of reverseGeocode(' + lat + ', ' + lng + ') = ' + JSON.stringify(result));
       let address = result[0];
       let str = '';


### PR DESCRIPTION
Ionic Build fails with following error :

```
Running app-scripts build: 
[15:27:48]  build dev started ... 
[15:27:48]  clean started ... 
[15:27:48]  clean finished in 3 ms 
[15:27:48]  copy started ... 
[15:27:48]  deeplinks started ... 
[15:27:48]  deeplinks finished in 126 ms 
[15:27:48]  transpile started ... 
[15:27:56]  typescript: src/pages/report-new/report-new.ts, line: 139 
            Argument of type '(result: NativeGeocoderReverseResult) => void' is not assignable to parameter of type 
            '(value: NativeGeocoderReverseResult[]) => void | PromiseLike<void>'. Types of parameters 'result' and 
            'value' are incompatible. Type 'NativeGeocoderReverseResult[]' is not assignable to type 
            'NativeGeocoderReverseResult'. Property 'countryCode' is missing in type 'NativeGeocoderReverseResult[]'. 

     L138:    str += address.administrativeArea + ", ";
     L140:  if (address.countryName) {

Error: Failed to transpile program
    at new BuildError (/Users/vittal/Downloads/Ionic-MFP-App-master/IonicMobileApp/node_modules/@ionic/app-scripts/dist/util/errors.js:16:28)
    at /Users/vittal/Downloads/Ionic-MFP-App-master/IonicMobileApp/node_modules/@ionic/app-scripts/dist/transpile.js:159:20
    at Promise (<anonymous>)
    at transpileWorker (/Users/vittal/Downloads/Ionic-MFP-App-master/IonicMobileApp/node_modules/@ionic/app-scripts/dist/transpile.js:107:12)
    at Object.transpile (/Users/vittal/Downloads/Ionic-MFP-App-master/IonicMobileApp/node_modules/@ionic/app-scripts/dist/transpile.js:64:12)
    at /Users/vittal/Downloads/Ionic-MFP-App-master/IonicMobileApp/node_modules/@ionic/app-scripts/dist/build.js:109:82
    at <anonymous>
```